### PR TITLE
migrate google sheet to supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=https://<project-ref>.supabase.co/functions/v1/airport-pickup

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 supabase_notes.txt
+docs

--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,19 @@
 
 # misc
 .DS_Store
+.env
+.env.*
+!.env.example
 .env.local
 .env.development.local
 .env.test.local
 .env.production.local
+src/.env
+src/keys.json
+supabase/functions/.env
+supabase/.temp
 
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+supabase_notes.txt

--- a/backend_appscript/backend.gs
+++ b/backend_appscript/backend.gs
@@ -1,0 +1,1010 @@
+const time_option = { hour12: false };
+const timeZone = "est"; //note that est is the same as cdt, it is used here because the system doesn't support cdt 
+const vol_start_col_num = 9;
+const matchvol_firstname_col_num = 10;
+const matchvol_lastname_col_num	= 11;
+const matchvol_phone_col_num = 12;
+const	matchvol_email_col_num = 13;
+const matchvol_wechat_col_num = 14;
+const vol_firstname_col_num = 1;
+const vol_lastname_col_num	= 2;
+const vol_phone_col_num = 3;
+const	vol_email_col_num = 4;
+const vol_wechat_col_num = 5;
+const vol_confirmed = 7;
+const vol_count_col_num = 6;
+const vol_notified_col_num = 8;
+
+/* column number for both defined here*/
+const firstname_col_num = 1;
+const lastname_col_num = 2;
+const phone_col_num = 3;
+const email_col_num = 4;
+const wechat_col_num = 5;
+const airport_col_num = 6; 
+const arr_time_col_num = 7;
+const flight_num_col_num = 8;
+const status_num_col_num = 9;
+// DB used for test
+const test_db_url = "1iqVDDJ2UPLThz-ZxvAXy5zdLh21b-8nEUd9imv3AE5E";
+//1iqVDDJ2UPLThz-ZxvAXy5zdLh21b-8nEUd9imv3AE5E
+// DB used for product
+const prod_db_url = "1wi5GHt2LyEQgvL8_I_-ysRg5H-5UTbYl9l_lgJG6ViM";
+//new prod_db: 1wi5GHt2LyEQgvL8_I_-ysRg5H-5UTbYl9l_lgJG6ViM
+const db = SpreadsheetApp.openById(prod_db_url);
+
+function doGet(e) {
+  var action = e.parameter.action;
+  //spreadsheet link: https://docs.google.com/spreadsheets/d/1T_YHlkxXlmUM7MWA0obevTBGf5cjQtdsYdW7X2a71-g/edit#gid=0
+
+//get the table out
+
+  var sheetMatch = db.getSheetByName("新生&志愿者");
+   
+  switch(action) {
+    case "get_all":
+      return do_get_all(e, sheetMatch);
+      break;
+    return response().json({
+      status: false,
+      message: 'silent!'
+    });
+  }
+}
+
+function doPost(e){
+  var action = e.parameter.action;
+
+  // Supabase uses this Apps Script deployment only as an email relay.
+  // Keep this before any spreadsheet access so email sending does not depend on
+  // the old Google Sheets table names.
+  if (action === "send_email") {
+    return do_send_email(e);
+  }
+
+  //spreadsheet link: https://docs.google.com/spreadsheets/d/1T_YHlkxXlmUM7MWA0obevTBGf5cjQtdsYdW7X2a71-g/edit#gid=0
+
+
+  // get tables out
+  var sheetMatch = db.getSheetByName("新生&志愿者");
+  var sheetVol = db.getSheetByName("志愿者");
+  var sheetStud = db.getSheetByName("新生");
+  
+  switch(action) {
+    case "insert_student":
+        return do_insert_student(e, sheetStud, sheetMatch);
+        break;
+    case "insert_new_vol":
+        return do_insert_new_vol(e, sheetVol);
+        break;
+    case "student_login_search":
+        return do_student_login_search(e, sheetMatch);
+        break;
+    case "volunteer_login_search":
+        return do_volunteer_login_search(e, sheetVol, sheetMatch);
+        break;
+    case "match":
+        return do_match(e, sheetMatch, sheetVol, sheetStud);
+        break;
+    case "change_time":
+        return do_change_time(e, sheetVol);
+        break;
+    case "delete_student":
+        return do_delete_new_student(e, sheetStud, sheetMatch, sheetVol);
+        break;
+    case "delete_match_from_volunteer":
+        return do_delete_match_from_volunteer(e, sheetVol, sheetMatch);
+        break;
+    return response().json({
+      status: false,
+      message: 'silent!'
+    });
+  }
+  
+}
+
+
+function LogTest() {
+  var db = SpreadsheetApp.openById("1WtsdrTkDb5nVS7aOAxt5aAaZ0mU532YpiONiuEZAXzE");
+  var sheet = db.getSheetByName("新生");
+  var dataRange = sheet.getDataRange();
+  var dataValues = dataRange.getValues();
+  Logger.log(dataValues[1][status_num_col_num]);
+  Logger.log(dataValues[1][status_num_col_num] == null);
+  Logger.log(dataValues[1][status_num_col_num] == "");
+
+}
+
+
+/* 
+This function happens when we sent all information for all dates initially to the front end. 
+Front end needs:
+  Events to be grouped by dates, and within dates grouped by time 
+*/
+function do_get_all(req, sheet){
+
+  //var db = SpreadsheetApp.openById("1wi5GHt2LyEQgvL8_I_-ysRg5H-5UTbYl9l_lgJG6ViM/edit#gid=24990355");
+
+  /*Just for testing*/
+  // var test_date_string = "2024-07-01T04:26:53.000Z";
+  // var test_date = new Date(test_date_string);
+  // var test_hour = test_date.getHours();
+  // var test_UTChour = test_date.getUTCHours();
+  // console.log("The test hour is: " + test_hour + ", UTC hour is: " + test_UTChour);
+  // var test_date = formatDate(test_date);
+  // console.log("The test date is: " + test_date );
+  /*Just for testing*/
+
+  // // get tables out
+  //var sheet = db.getSheetByName("新生&志愿者");
+
+  var hour_int2str = {};
+  for (var i = 0; i < 24; i += 2) {
+    var start = i < 10 ? "0" + i + ":00" : i + ":00";
+    var end = i + 2 < 10 ? "0" + (i + 2) + ":00" : (i + 2) + ":00";
+    hour_int2str[i] = start + "-" + end;
+  }
+
+  var all_dates = {};
+
+  var dataRange = sheet.getDataRange();
+  var dataValues = dataRange.getValues();
+
+  for (var i = 1; i < dataValues.length; i++) {
+    var record = dataValues[i];
+    // only get unmatched student info
+    if (record[matchvol_email_col_num] !== "") { continue; }
+    var arrivingTime = record[arr_time_col_num]; // Assuming "arrivingTime" column is at index 7 (0-based)
+    // Convert arrivingTime to a Date object
+    var arrivingTimeDate = new Date(arrivingTime);
+
+    // Extract the date and time components from the Date object
+    var date = formatDate(arrivingTimeDate);
+    
+    console.log(date);
+    // var time = arrivingTimeDate.toLocaleTimeString(time_option);
+    // convert UTC to CDT
+    var hour = (arrivingTimeDate.getUTCHours() + 24 - 5) % 24;
+    console.log(i + ": " + hour);
+    var airport = record[airport_col_num];
+
+    // TODO:这里的condition怎么办？？？
+    if (!(date in all_dates)) {
+      all_dates[date] = create_structure_for_date();
+      all_dates[date]["date"] = date;
+    }
+    all_dates[date][airport]["TotalToBePicked"] += 1;
+    all_dates[date][airport][hour_int2str[Math.floor(hour/2) * 2]] += 1;
+
+  }
+
+  //delete all records that have value of 0
+  for (const [date, date_value] of Object.entries(all_dates)) {
+
+    //date_value is a dictionary with 3 keys: "IAH", "HOU", "Date".
+    for (const [time, num] of Object.entries(date_value["IAH"])) {
+      if (num == 0) {
+        delete date_value["IAH"][time];
+      } 
+    }
+
+    for (const [time, num] of Object.entries(date_value["HOU"])) {
+      if (num == 0) {
+        delete date_value["HOU"][time];
+      } 
+    }
+    if (Object.keys(date_value["IAH"]).length === 0) {
+      delete all_dates[date]["IAH"];
+    }
+    if (Object.keys(date_value["HOU"]).length === 0) {
+      delete all_dates[date]["HOU"];
+    }
+  }
+  console.log(all_dates);
+
+  return response().json({
+    status: true,
+    events: all_dates,
+  });
+
+}
+
+function formatDate(date) {
+  var year = date.getFullYear();
+  var month = ("0" + (date.getMonth() + 1)).slice(-2);
+  var day = ("0" + (date.getDate())).slice(-2);
+
+  return year + '-' + month + '-' + day;
+}
+
+
+function create_structure_for_date(){
+
+  var date_value = {};
+  date_value["IAH"] = {};
+  date_value["HOU"] = {};
+  date_value["date"] = "";
+  date_value["IAH"]["TotalToBePicked"] = 0;
+  date_value["HOU"]["TotalToBePicked"] = 0;
+
+  for (var hours = 0; hours < 24; hours += 2) {
+
+    var startHour = hours < 10 ? "0" + hours + ":00" : hours + ":00";
+    var endHour = hours + 2 < 10 ? "0" + (hours + 2) + ":00" : (hours + 2) + ":00";
+  
+    var final_str = startHour + "-" + endHour;
+    date_value["IAH"][final_str] = 0;
+    date_value["HOU"][final_str] = 0;
+  }
+
+  return date_value;
+}
+
+
+
+function do_insert_student(req, stud_sheet, match_sheet) {
+  var data = JSON.parse(req.postData.contents); // Assuming the request payload is in JSON format
+  var dataRange = stud_sheet.getDataRange();
+  var stud_values = dataRange.getValues();
+
+  var return_val = {
+      status: true,
+      message: "done post"
+    }
+
+  //loop through stud_sheet to make sure that we don't have repetitive
+  for (var i = 1; i < stud_values.length; i++) {
+    var row = stud_values[i];
+    var rowEmail = row[email_col_num];
+    
+    if (rowEmail.toLowerCase() === data.email.toLowerCase()) {
+      return_val.status = false;
+      return response().json(return_val);
+    }
+  }
+
+  
+  // Get the last used ID from the spreadsheet
+  var lastId = stud_sheet.getRange(stud_sheet.getLastRow(), 1).getValue();
+  
+  // Calculate the next ID by incrementing the last ID
+  var nextId = lastId ? lastId + 1 : 1;
+  
+  var newRow = [
+    nextId,
+    data.firstname,
+    data.lastname,
+    data.phone,
+    data.email,
+    data.wechat,
+    data.airport,
+    data.arriving_time,
+    data.flight_number,
+  ];
+  
+  stud_sheet.appendRow([ ...newRow, "Not matched"]);
+  match_sheet.appendRow(newRow);
+
+  //send email confirmation for signup to student
+  student_signup_send_email(data.firstname, data.lastname, data.email);
+  return response().json(return_val);
+}
+
+
+
+function do_insert_new_vol(req, sheet){
+
+  var data = JSON.parse(req.postData.contents); // Assuming the request payload is in JSON format
+  var dataRange = sheet.getDataRange();
+  var values = dataRange.getValues();
+
+  var return_val = {
+      status: true,
+      message: "done post"
+    }
+
+  //loop through stud_sheet to make sure that we don't have repetitive
+  for (var i = 1; i < values.length; i++) {
+    var row = values[i];
+    var rowEmail = row[email_col_num];
+    if (rowEmail.toLowerCase() === data.email.toLowerCase()) {
+      console.log(rowEmail + data.email);
+      return_val.status = false;
+      console.log(return_val);
+      return response().json(return_val);
+    }
+  }
+
+  
+  // Get the last used ID from the spreadsheet
+  var lastId = sheet.getRange(sheet.getLastRow(), 1).getValue();
+  
+  // Calculate the next ID by incrementing the last ID
+  var nextId = lastId ? lastId + 1 : 1;
+  
+  var newRow = [
+    nextId,
+    data.firstname,
+    data.lastname,
+    data.phone,
+    data.email,
+    data.wechat,
+    0
+  ];
+  
+  sheet.appendRow(newRow);
+  volunteer_signup_send_email(data.firstname, data.lastname, data.email);
+  return response().json(return_val);
+}
+
+function do_student_login_search(req, match_sheet) {
+  var data = JSON.parse(req.postData.contents); // Assuming the request payload is in JSON format
+  var dataRange = match_sheet.getDataRange();
+  var values = dataRange.getValues();
+  
+  var firstname = data.firstname;
+  var lastname = data.lastname;
+  var email = data.email;
+
+  var return_val = {
+    found: false,
+    confirmed: true,
+    record: {},
+    wechat: "", //match_row[wechat_col_num],
+    airport: "", //match_row[airport_col_num],
+    arriving_time: "", //match_row[arr_time_col_num],
+    flight_number: "" //match_row[flight_num_col_num]
+  };
+  
+  for (var i = 1; i < values.length; i++) {
+    var row = values[i];
+    var rowFirstname = row[firstname_col_num];
+    var rowLastname = row[lastname_col_num];
+    var rowEmail = row[email_col_num];
+    
+    if (rowFirstname.toLowerCase() == firstname.toLowerCase() && rowLastname.toLowerCase() == lastname.toLowerCase() && rowEmail == email) {
+      return_val.found = true;
+      return_val.wechat = row[wechat_col_num];
+      return_val.airport = row[airport_col_num];
+      return_val.arriving_time = row[arr_time_col_num];
+      return_val.flight_number = row[flight_num_col_num];
+      if (row[matchvol_email_col_num] !== "") { //if this student is picked by a volunteer
+        return_val.record = {
+          vol_firstname: row[matchvol_firstname_col_num],
+          vol_lastname: row[matchvol_lastname_col_num],
+          vol_phone: row[matchvol_phone_col_num],
+          vol_email: row[matchvol_email_col_num],
+          vol_wechat: row[matchvol_wechat_col_num]
+        };
+      }
+    }
+  }
+  
+  return response().json(return_val);
+}
+
+
+function do_volunteer_login_search(req, vol_sheet, match_sheet) {
+  var data = JSON.parse(req.postData.contents); // Assuming the request payload is in JSON format
+  var vol_dataRange = vol_sheet.getDataRange();
+  var vol_values = vol_dataRange.getValues();
+  var match_dataRange = match_sheet.getDataRange();
+  var match_values = match_dataRange.getValues();
+  
+  var fisrtname = data.firstname;
+  var lastname = data.lastname;
+  var email = data.email;
+
+  var return_val = {
+    found: false,
+    confirmed: false,
+    record: []
+  };
+  
+  for (var i = 1; i < vol_values.length; i++) {
+    var row = vol_values[i];
+    var rowFirstname = row[firstname_col_num];
+    var rowLastname = row[lastname_col_num];
+    var rowEmail = row[email_col_num];
+    
+    if (rowFirstname == fisrtname && rowLastname == lastname && rowEmail == email) {
+      return_val.found = true;
+      if (row[vol_confirmed] !== "") { //if volunteer is confirmed
+        return_val.confirmed = true;
+        //search in the matching sheet to find a student that has same volunteer email
+        var student_list = [];
+        for (var j = 1; j < match_values.length; j++) {
+          var match_row = match_values[j];
+          if (match_row[matchvol_email_col_num] === rowEmail) { // if the current student in iteration is picked up by volunteer with same email as rowEmail.
+            //then append to the student list
+            var student_obj = {
+              firstname: match_row[firstname_col_num],
+              lastname: match_row[lastname_col_num],
+              phone: match_row[phone_col_num],
+              email: match_row[email_col_num],
+              wechat: match_row[wechat_col_num],
+              airport: match_row[airport_col_num],
+              arriving_time: match_row[arr_time_col_num],
+              flight_number: match_row[flight_num_col_num]
+            }
+            student_list.push(student_obj);
+          }
+        }
+        return_val.record = student_list;
+      }
+    }
+  }
+  
+  return response().json(return_val);
+}
+
+/**
+ * req: request object
+ * sheet: sheetMatch
+ * given date, hour, airport, number, vol_email
+ * JSON {date: '2022-03-15', hour: '10:00-12:00', airport:"IAH", number: 2, vol_email: hs56@rice.edu} //note that 2AM is written as 02:00 not 2:00
+ * Find appropriate person
+ * If req.number > available_num, fill available num and return num. 
+ * 
+ * return a num. (0 for failed, >0 for actual number allocated.)
+ */
+function do_match(req, match_sheet, vol_sheet, stud_sheet){
+
+  var match_dataRange = match_sheet.getDataRange();
+  var match_values = match_dataRange.getValues();
+
+  var vol_dataRange = vol_sheet.getDataRange();
+  var vol_values = vol_dataRange.getValues();
+
+  var stud_dataRange = stud_sheet.getDataRange();
+  var stud_values = stud_dataRange.getValues();
+
+  var data = JSON.parse(req.postData.contents); 
+  var req_date = data.date;
+  var req_start_hour = Number(data.hour.substring(0, 2));
+  var req_end_hour = Number(data.hour.substring(6, 8));
+  var req_airport = data.airport;
+  var req_number = data.number;
+  var req_vol_email = data.vol_email;
+  var num_allocated = 0;
+  var vol_row_idx = 0;
+
+
+  for (var i = 1; i < match_values.length; i++) {
+    //changed === to >= for safety
+    if (num_allocated >= req_number) {
+      break;
+    }
+    var match_record = match_values[i];
+    var arrivingTimeDate = new Date(match_record[arr_time_col_num]);
+    var pickup_date = formatDate(arrivingTimeDate);
+    var pickup_hour = (arrivingTimeDate.getUTCHours() + 24 - 5) % 24;
+    var airport = match_record[airport_col_num];
+    var vol_email = match_record[matchvol_email_col_num];
+    if (
+      req_vol_email !== null &&
+      vol_email === "" &&
+      pickup_date === req_date &&
+      pickup_hour >= req_start_hour &&
+      pickup_hour < req_end_hour &&
+      airport === req_airport
+    ) {
+      // search volunteer info by volunteer email
+      for (var j = 1; j < vol_values.length; j++) {
+        if (vol_values[j][vol_email_col_num] === req_vol_email) {
+          vol_row_idx = j;
+          if (vol_values[j][vol_count_col_num] >= 10) {
+            return response().json(
+              {
+            has_reached_limit: true,
+            num_allocated
+              }
+            )
+          }
+          match_sheet.getRange(i + 1, matchvol_firstname_col_num + 1).setValue(vol_values[vol_row_idx][vol_firstname_col_num])
+          match_sheet.getRange(i + 1, matchvol_lastname_col_num + 1).setValue(vol_values[vol_row_idx][vol_lastname_col_num])
+          match_sheet.getRange(i + 1, matchvol_phone_col_num + 1).setValue(vol_values[vol_row_idx][vol_phone_col_num])
+          match_sheet.getRange(i + 1, matchvol_email_col_num + 1).setValue(vol_values[vol_row_idx][vol_email_col_num])
+          match_sheet.getRange(i + 1, matchvol_wechat_col_num + 1).setValue(vol_values[vol_row_idx][vol_wechat_col_num])
+          num_allocated += 1;
+          new_match_send_to_stud_email(match_record[firstname_col_num], match_record[lastname_col_num], vol_values[vol_row_idx][vol_firstname_col_num], vol_values[vol_row_idx][vol_lastname_col_num], match_record[email_col_num], vol_values[vol_row_idx][vol_email_col_num], vol_values[vol_row_idx][vol_wechat_col_num]);
+          // add log if necessary
+          // const log_sheet = db.getSheetByName("日志");
+          // log_sheet.appendRow([new Date(), "INFO", `MATCHED : Student: ${match_record[firstname_col_num]} ${match_record[lastname_col_num]}, Volunteer: ${vol_values[vol_row_idx][vol_firstname_col_num]} ${vol_values[vol_row_idx][vol_lastname_col_num]}`]);
+
+          //changed j to k to avoid same var name in same scope
+          for (var k = 1; k < stud_values.length; k++) {
+            if (stud_values[k][email_col_num] === match_record[email_col_num]) {
+              stud_sheet.getRange(k + 1, 10).setValue("Matched");
+              break;
+            }
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  vol_values[vol_row_idx][vol_count_col_num] += num_allocated;
+  vol_sheet.getRange(vol_row_idx+1, vol_count_col_num+1).setValue(vol_values[vol_row_idx][vol_count_col_num]);
+
+
+  return response().json(
+    {
+      num_allocated
+    }
+  )
+}
+
+
+/**
+ * Req format: {firstname: Sarah, lastname: Yao, email: jy75@rice.edu}
+ * Effect: delete the entire row in 新生， 新生&志愿者 sheet
+ */
+function do_delete_new_student(req, stud_sheet, match_sheet, vol_sheet){
+
+  var data = JSON.parse(req.postData.contents); 
+  var match_dataRange = match_sheet.getDataRange();
+  var match_values = match_dataRange.getValues();
+  let isFound = false;
+
+  var stud_dataRange = stud_sheet.getDataRange();
+  var stud_values = stud_dataRange.getValues();
+  
+  var vol_dataRange = vol_sheet.getDataRange();
+  var vol_values = vol_dataRange.getValues();
+
+  var req_firstname = data.firstname.toLowerCase();
+  var req_lastname = data.lastname.toLowerCase();
+  var req_email = data.email.toLowerCase();
+
+  for (var i = 1; i < stud_values.length; i++) {
+    var row = stud_values[i];
+    console.log(typeof row[firstname_col_num]);
+    var curr_firstname = row[firstname_col_num].toLowerCase();
+    var curr_lastname = row[lastname_col_num].toLowerCase();
+    var curr_email = row[email_col_num].toLowerCase();
+    // console.log(i + " " +curr_firstname + " " + curr_lastname + " ");
+    if (curr_firstname === req_firstname && curr_lastname === req_lastname && req_email === curr_email){
+      stud_sheet.deleteRow(i+1);
+      //add delete log
+      const log_sheet = db.getSheetByName("日志");
+      log_sheet.appendRow([new Date(), "INFO", `STUDENT DELETED : ${row[firstname_col_num]} ${row[lastname_col_num]}`]);
+      isFound = true;
+      break;
+    }
+  }
+
+  for (var i = 1; i < match_values.length; i++) {
+    var row = match_values[i];
+    var curr_firstname = row[firstname_col_num].toLowerCase();
+    var curr_lastname = row[lastname_col_num].toLowerCase();
+    var curr_email = row[email_col_num].toLowerCase();
+    var vol_email = row[matchvol_email_col_num].toLowerCase();
+    if (curr_firstname === req_firstname && curr_lastname === req_lastname && req_email === curr_email){
+      // delete_send_to_vol_email(match_values[i][firstname_col_num], match_values[i][lastname_col_num], match_values[i][matchvol_firstname_col_num], match_values[i][matchvol_lastname_col_num], match_values[i][matchvol_email_col_num]);
+
+      delete_student_send_to_student_email(match_values[i][firstname_col_num], match_values[i][lastname_col_num], match_values[i][email_col_num]);
+      if (row[matchvol_email_col_num] != "") {
+        delete_student_send_to_vol_email(match_values[i][firstname_col_num], match_values[i][lastname_col_num], match_values[i][matchvol_firstname_col_num], match_values[i][matchvol_lastname_col_num], match_values[i][matchvol_email_col_num]);
+      }
+
+      //add delete log
+      const log_sheet = db.getSheetByName("日志");
+      const match_record = row;
+      log_sheet.appendRow([new Date(), "INFO", `STUDENT UNMATCHED : Student: ${match_record[firstname_col_num]} ${match_record[lastname_col_num]}, Volunteer: ${match_record[matchvol_firstname_col_num]} ${match_record[matchvol_lastname_col_num]}`]);
+
+      match_sheet.deleteRow(i+1);
+      break;
+    }
+  }
+
+  if (isFound) {
+    // decrement volunteer's students count
+    for (var i = 1; i < vol_values.length; i++) {
+      var row = vol_values[i];
+      var cur_email = row[email_col_num].toLowerCase();
+      if (vol_email === cur_email){
+        // decrement the count
+        vol_sheet.getRange(i + 1, vol_count_col_num + 1).setValue(vol_values[i][vol_count_col_num] - 1)
+        break;
+      }
+    }
+  }
+
+  return response().json({status:isFound});
+}
+
+
+/**
+ * Req format: {"stud_email": "jy75@rice.edu", "vol_email": "jy75@rice.edu"};
+ * Effect: find the corresponding new student record in 新生&志愿者，delete the volunteer portion of the row.
+ */
+//Tim:volunteer email not deleted
+function do_delete_match_from_volunteer(req, vol_sheet, match_sheet){
+
+  // data = {"stud_email": "jy75@rice.edu", "vol_email": "jy75@rice.edu"};
+  // var vol_sheet = db.getSheetByName("志愿者");
+  // var match_sheet = db.getSheetByName("新生&志愿者");
+  var data = JSON.parse(req.postData.contents); 
+  var match_dataRange = match_sheet.getDataRange();
+  var match_values = match_dataRange.getValues();
+  let isFound = false;
+
+  var req_vol_email = data.vol_email.toLowerCase();
+  var req_stud_email = data.stud_email.toLowerCase();
+
+  var vol_values = vol_sheet.getDataRange().getValues();
+
+  // delete from match sheet
+  for (var i = 1; i < match_values.length; i++) {
+    var row = match_values[i];
+    var curr_vol_email = row[matchvol_email_col_num].toLowerCase();
+    var curr_stud_email = row[email_col_num].toLowerCase();
+    if (curr_vol_email === req_vol_email && curr_stud_email === req_stud_email){
+      // delete_send_to_student_email(match_values[i][firstname_col_num], match_values[i][lastname_col_num], match_values[i][matchvol_firstname_col_num], match_values[i][matchvol_lastname_col_num], match_values[i][email_col_num]);
+
+      delete_match_send_to_student_email(match_values[i][firstname_col_num], match_values[i][lastname_col_num], match_values[i][matchvol_firstname_col_num], match_values[i][matchvol_lastname_col_num], match_values[i][email_col_num]);
+
+      delete_match_send_to_vol_email(match_values[i][firstname_col_num], match_values[i][lastname_col_num], match_values[i][matchvol_firstname_col_num], match_values[i][matchvol_lastname_col_num], match_values[i][matchvol_email_col_num]);
+
+      //add delete log
+      const log_sheet = db.getSheetByName("日志");
+      const match_record = row;
+      log_sheet.appendRow([new Date(), "INFO", `VOL UNMATCHED : Student: ${match_record[firstname_col_num]} ${match_record[lastname_col_num]}, Volunteer: ${match_record[matchvol_firstname_col_num]} ${match_record[matchvol_lastname_col_num]}`]);
+
+      deleteFieldsInRow(i+1, matchvol_firstname_col_num + 1, matchvol_wechat_col_num+1, match_sheet);
+
+      isFound = true;
+      break;
+    }
+  }
+
+  if (isFound) {
+    // decrement volunteer's students count
+    for (var i = 1; i < vol_values.length; i++) {
+      var row = vol_values[i];
+      var cur_email = row[email_col_num].toLowerCase();
+      if (req_vol_email === cur_email){
+        // decrement the count
+        vol_sheet.getRange(i + 1, vol_count_col_num + 1).setValue(vol_values[i][vol_count_col_num] - 1)
+        break;
+      }
+    }
+  }
+  
+  return response().json({status:isFound});
+}
+
+
+
+/**
+ * Email-only webhook for the Supabase Edge Function.
+ * Req format: { to: "user@example.com", subject: "...", body: "..." }
+ */
+function do_send_email(req) {
+  var data = JSON.parse(req.postData.contents);
+
+  MailApp.sendEmail({
+    to: data.to,
+    subject: data.subject,
+    name: "RCSSA",
+    body: data.body
+  });
+
+  return response().json({
+    status: true
+  });
+}
+
+
+
+
+/* Helper functions */
+
+/**
+ * This helper sends email to student when student sign up successfully.
+ */
+function student_signup_send_email(stud_firstname, stud_lastname, stud_email){
+
+  MailApp.sendEmail({
+    to: stud_email,
+    // multi line string!
+    subject: `[DO NOT REPLY] You Have Signed up as New Student for the 2024 RCSSA Airport Pickup Program`,
+    name: "RCSSA",
+    body: `
+Dear ${stud_firstname} ${stud_lastname},
+
+Thank you for registering for the 2024 RCSSA Airport Pickup Program! We appreciate your interest and look forward to assisting you. We wanted to provide you with some important information regarding the program.
+
+Please note that the matching process may take some time as we strive to find the best volunteer to assist you. Rest assured, we will notify you as soon as a volunteer has been successfully matched with you.
+
+However, we want to emphasize that registering for the program does not guarantee a matched volunteer due to the availability of our volunteers. Therefore, we encourage you to keep alternative options in mind, such as using Houston's public transportation or services like Uber and Lyft.
+
+If you need to make any changes to your flight information or cancel your request, please refer to the instructions published on the RCSSA WeChat platform. There, you will find the necessary steps to follow.
+
+Should you have any further questions or concerns about the program, please feel free to leave us a message at https://rcssa.rice.edu/about/#contact-us
+
+Thank you once again for your participation in the RCSSA Airport Pickup Program. We wish you a wonderful day.
+
+
+Sincerely,
+Rice Chinese Students and Scholars Association
+  `
+  });
+}
+
+/**
+ * This function should be registered under a trigger that triggers daily.
+ */
+function vol_confirmed_send_email_trigger(){
+
+  var sheetVol = db.getSheetByName("志愿者");
+
+  var vol_dataRange = sheetVol.getDataRange();
+  var vol_values = vol_dataRange.getValues();
+
+  for (var i = 1; i < vol_values.length; i++) {
+    var row = vol_values[i];
+    if (row[vol_confirmed] === 1 && row[vol_notified_col_num] !== 1) {
+      try {
+        vol_confirmed_send_email_helper(row[vol_firstname_col_num], row[vol_lastname_col_num], row[vol_email_col_num]);
+        sheetVol.getRange(i + 1, vol_notified_col_num + 1).setValue(1);
+      } catch {
+        Logger.log('Failed to send email for row ' + i + ': ' + error.message);
+      }
+    }
+  }
+}
+
+/**
+ * This helper sends email to vol when they got confirmed.
+ */
+function vol_confirmed_send_email_helper(vol_firstname, vol_lastname, vol_email){
+
+  MailApp.sendEmail({
+    to: vol_email,
+    // multi line string!
+    subject: `[DO NOT REPLY] Your Volunteer Status for the 2024 RCSSA Airport Pickup Program Has Been Approved`,
+    name: "RCSSA",
+    body: `
+Dear ${vol_firstname} ${vol_lastname},
+
+Congratulations! We are delighted to inform you that your volunteer status for the 2024 RCSSA Airport Pickup Program has been approved!
+
+You are now able to proceed to the website and begin matching with students who have requested airport pickup. If you need to make a new match or cancel an existing match, please refer to the instructions published on the RCSSA WeChat platform.
+
+If you have any further questions or concerns about the program, please do not hesitate to contact us. You can leave us a message at https://rcssa.rice.edu/about/#contact-us
+
+Once again, thank you for signing up to volunteer for the program. Your contribution will undoubtedly have a positive impact on the arrival experience of our students. We wish you a wonderful day.
+
+Best regards,
+Rice Chinese Students and Scholars Association
+  `
+  });
+}
+
+/**
+ * This helper sends email to student when volunteer sign up successfully.
+ */
+function volunteer_signup_send_email(vol_firstname, vol_lastname, vol_email){
+
+  MailApp.sendEmail({
+    to: vol_email,
+    // multi line string!
+    subject: `[DO NOT REPLY] You Have Signed up as Volunteer for the 2024 RCSSA Airport Pickup Program`,
+    name: "RCSSA",
+    body: `
+Dear ${vol_firstname} ${vol_lastname},
+
+Thank you for signing up to volunteer for the 2024 RCSSA Airport Pickup Program! We greatly appreciate your willingness to assist our new students. Your efforts will undoubtedly make a positive impact on the student's arrival experience. We wanted to provide you with some important information regarding the program.
+
+Please note that we are currently in the process of verifying the identity of all volunteers. This verification step ensures the safety and security of our participants. We anticipate that this process may take up to several days to complete.
+
+Once your identity has been successfully verified, we will promptly notify you, and you can begin matching with new students who request airport pickup.
+
+We sincerely appreciate your patience and understanding during this verification process. Should you have any further questions or concerns about the program, please feel free to leave us a message at https://rcssa.rice.edu/about/#contact-us
+
+Thank you once again for your participation in the RCSSA Airport Pickup Program. We wish you a wonderful day.
+
+Best regards,
+Rice Chinese Students and Scholars Association
+  `
+  });
+}
+
+/**
+ * This helper sends email to volunteer when they are being confirmed
+ */
+function volunteer_confirmed_send_email(vol_firstname, vol_lastname, vol_email){
+
+  MailApp.sendEmail({
+    to: vol_email,
+    // multi line string!
+    subject: `[DO NOT REPLY] Your Volunteer Status for the 2024 RCSSA Airport Pickup Program Has Been Approved`,
+    name: "RCSSA",
+    body: `
+Dear ${vol_firstname} ${vol_lastname},
+
+Congratulations! We are delighted to inform you that your volunteer status for the 2024 RCSSA Airport Pickup Program has been approved!
+
+You are now able to proceed to the website and begin matching with students who have requested airport pickup. If you need to make a new match or cancel an existing match, please refer to the instructions published on the RCSSA WeChat platform.
+
+If you have any further questions or concerns about the program, please do not hesitate to contact us. You can leave us a message at https://rcssa.rice.edu/about/#contact-us
+
+Once again, thank you for signing up to volunteer for the program. Your contribution will undoubtedly have a positive impact on the arrival experience of our students. We wish you a wonderful day.
+
+Best regards,
+Rice Chinese Students and Scholars Association
+  `
+  });
+}
+
+/**
+ * The helper function that sends the email to corresponding student when a student cancels
+ * Parameters: all information is about the new_student. receiver: stud's email
+ */
+function delete_student_send_to_student_email(stud_firstname, stud_lastname, stud_email){
+
+  MailApp.sendEmail({
+    to: stud_email,
+    // multi line string!
+    subject: `[DO NOT REPLY] You Have Cancelled Your Airport Pickup Request`,
+    name: "RCSSA",
+    body: `
+Dear ${stud_firstname} ${stud_lastname},
+
+We hope this message finds you well. We wanted to inform you that your airport pickup request for the 2024 RCSSA Airport Pickup Program has been canceled.
+
+If you want to make a new request, you can refer to the instructions published on the RCSSA WeChat platform. 
+
+For any questions or concerns about the program, you can leave us a message at https://rcssa.rice.edu/about/#contact-us
+
+We wish you a wonderful day.
+
+Best regards,
+Rice Chinese Students and Scholars Association
+  `
+  });
+}
+
+/**
+ * The helper function that sends the email to corresponding volunteer when a student deletes oneself.
+ * Parameters: all information is about the new_student. receiver: vol's email
+ */
+function delete_student_send_to_vol_email(stud_firstname, stud_lastname, vol_firstname, vol_lastname, vol_email){
+  
+  MailApp.sendEmail({
+    to: vol_email,
+    // multi line string!
+    subject: `[DO NOT REPLY] You Have Been Unmatched for One Airport Pickup`,
+    name: "RCSSA",
+    body: `
+Dear ${vol_firstname} ${vol_lastname},
+
+Thank you for signing up for the 2024 RCSSA Airport Pickup Program. We appreciate your willingness to volunteer and provide assistance to our new students.
+
+We regret to inform you that the student, ${stud_firstname} ${stud_lastname}, whom you were assigned to for airport pickup, has canceled their confirmation. For an updated list of airport pickup matches, please visit our website. We understand that circumstances can change, and we appreciate your understanding in this matter.
+
+If you are still available and interested in volunteering for the program, we encourage you to check for any new matching opportunities on the website. There may be other students who require airport pickup and would greatly benefit from your assistance.
+
+Once again, we thank you for your willingness to volunteer and support our program. If you have any questions or need further assistance, please feel free to contact us at https://rcssa.rice.edu/about/#contact-us
+
+We wish you a wonderful day.
+
+Best regards,
+Rice Chinese Students and Scholars Association
+  `
+  });
+}
+
+/**
+ * The helper function that sends the email to corresponding student when a match is cancelled
+ * Parameters: all information is about the new_student. receiver: stud's email
+ */
+function delete_match_send_to_student_email(stud_firstname, stud_lastname, vol_firstname, vol_lastname, stud_email){
+
+  MailApp.sendEmail({
+    to: stud_email,
+    // multi line string!
+    subject: `[DO NOT REPLY] You Have Been Unmatched for Your Airport Pickup Request`,
+    name: "RCSSA",
+    body: `
+Dear ${stud_firstname} ${stud_lastname}, 
+
+Thank you for signing up for the 2024 RCSSA Airport Pickup Program. 
+
+We regret to inform you that your assigned volunteer, ${vol_firstname} ${vol_lastname}, has canceled their confirmation. We understand that circumstances can change, and we are working diligently to find a new volunteer for you.
+
+Rest assured, we are actively seeking a replacement volunteer and will inform you as soon as a new match is found. We appreciate your patience in this matter.
+
+If you have any questions or require further assistance, please do not hesitate to contact us at https://rcssa.rice.edu/about/#contact-us
+
+We wish you a wonderful day.
+
+Best regards,
+Rice Chinese Students and Scholars Association
+  `
+  });
+}
+
+/**
+ * The helper function that sends the email to corresponding volunteer when a match is cancelled
+ * Parameters: all information is about the new_student. receiver: vol's email
+ */
+function delete_match_send_to_vol_email(stud_firstname, stud_lastname, vol_firstname, vol_lastname, vol_email){
+
+  MailApp.sendEmail({
+    to: vol_email,
+    // multi line string!
+    subject: `[DO NOT REPLY] You Have Been Unmatched for One Airport Pickup`,
+    name: "RCSSA",
+    body: `
+Dear ${vol_firstname} ${vol_lastname},
+
+We hope this message finds you well. We wanted to inform you that your airport pickup match for the 2024 RCSSA Airport Pickup Program with ${stud_firstname} ${stud_lastname} has been canceled.
+
+We appreciate your willingness to volunteer and apologize for any inconvenience caused. If you are still available and interested in volunteering for the program, we encourage you to regularly check the website for any new matching opportunities.
+
+If you have any questions or require further assistance, please do not hesitate to contact us at https://rcssa.rice.edu/about/#contact-us
+
+We wish you a wonderful day.
+
+Best regards,
+Rice Chinese Students and Scholars Association
+  `
+  });
+}
+
+
+/**
+ * The helper function that sends the email to corresponding student when one is being matched.
+ * Parameters: receiver: stud's email
+ */
+function new_match_send_to_stud_email(stud_firstname, stud_lastname, vol_firstname, vol_lastname, stud_email, vol_email, vol_wechat){
+
+  MailApp.sendEmail({
+    to: stud_email,
+    // multi line string!
+    subject: `[DO NOT REPLY] You Have Been Matched with A Volunteer for Your Airport Pickup Request`,
+    name: "RCSSA",
+    body: `
+Dear ${stud_firstname} ${stud_lastname},
+
+Thank you for signing up for the 2024 RCSSA Airport Pickup Program. We appreciate your participation and look forward to assisting you.
+
+We are pleased to inform you that you have been matched with a volunteer to pick you up from the airport! Your assigned volunteer for airport pickup is ${vol_firstname} ${vol_lastname}. Please reach out to ${vol_firstname} ${vol_lastname} to coordinate the details of your airport pickup. You can contact them via email at ${vol_email} or through WeChat at ${vol_wechat}.
+
+If, for any reason, you no longer need the airport pickup service from us, we kindly request that you inform both the volunteer and our team. To inform our team, please cancel your request from our website.
+
+If you have any questions or need further assistance, please do not hesitate to contact us at https://rcssa.rice.edu/about/#contact-us
+
+We wish you a wonderful day.
+
+Best regards,
+Rice Chinese Students and Scholars Association
+  `
+  });
+}
+
+
+
+
+function deleteFieldsInRow(rowIndex, startColumn, endColumn, sheet) {
+  var range = sheet.getRange(rowIndex, startColumn, 1, endColumn - startColumn + 1);
+  // const log_sheet = db.getSheetByName("日志");  
+  // log_sheet.appendRow([new Date(), "INFO", range.getValues() + " was deleted from " + sheet.getName()]);
+  range.clear();
+}
+
+
+
+function response() {
+   return {
+      json: function(data) {
+         return ContentService
+            .createTextOutput(JSON.stringify(data))
+            .setMimeType(ContentService.MimeType.JSON);
+      }
+   }
+}

--- a/docs/supabase-migration.md
+++ b/docs/supabase-migration.md
@@ -1,0 +1,83 @@
+# Supabase Migration
+
+This project used Google Apps Script plus Google Sheets as the backend. The Supabase version keeps the frontend API shape the same by exposing one Edge Function:
+
+```text
+https://<project-ref>.supabase.co/functions/v1/airport-pickup?action=<action>
+```
+
+## Database Model
+
+- `students`: replaces the `新生` sheet.
+- `volunteers`: replaces the `志愿者` sheet.
+- `matches`: replaces the `新生&志愿者` sheet. Every student has one match row; `volunteer_id` is `null` until matched.
+- `app_logs`: replaces the `日志` sheet.
+
+The migration enables RLS on all tables. The browser should not read or write tables directly; the Edge Function uses the service role key server-side.
+
+## Deployment
+
+1. Install and log in to the Supabase CLI.
+
+```sh
+supabase login
+```
+
+2. Link this repo to your Supabase project.
+
+```sh
+supabase link --project-ref <project-ref>
+```
+
+3. Push the database schema.
+
+```sh
+supabase db push
+```
+
+4. Optional: configure Google Apps Script email relay.
+
+```sh
+supabase secrets set GOOGLE_EMAIL_WEBHOOK_URL=<google-apps-script-web-app-url>
+```
+
+The Google Apps Script deployment must include the `send_email` action from `backend_appscript/backend.gs`. Without this secret, the Edge Function still works but logs that email was skipped.
+
+5. Deploy the Edge Function.
+
+```sh
+supabase functions deploy airport-pickup
+```
+
+6. Point the React app to Supabase by creating a local `.env.local`.
+
+```sh
+REACT_APP_API_URL=https://<project-ref>.supabase.co/functions/v1/airport-pickup
+```
+
+7. Rebuild and deploy the frontend.
+
+```sh
+npm run build
+npm run deploy
+```
+
+## Data Migration
+
+Export each Google Sheet tab as CSV and import into Supabase in this order:
+
+1. `新生` -> `students`
+2. `志愿者` -> `volunteers`
+3. `新生&志愿者` -> `matches`
+
+For `matches`, map student emails to `students.id` and volunteer emails to `volunteers.id`. Leave `volunteer_id` blank for unmatched students.
+
+Volunteers are inserted with `confirmed = false`. After reviewing a volunteer in the Supabase dashboard, set `confirmed = true` so they can log in and match students.
+
+## Security Cleanup
+
+This repo currently contains Google service account credentials in tracked files. Before production:
+
+- Rotate the Google service account key.
+- Rotate any Supabase database password that was written to local notes.
+- Remove committed secrets from git history.

--- a/progress.txt
+++ b/progress.txt
@@ -1,0 +1,39 @@
+Supabase migration progress
+
+Done
+- Supabase project connected: ccyusgdcruwkpdyteogf
+- Database migration applied.
+- Tables created: students, volunteers, matches, app_logs.
+- Matching logic moved to Supabase/Postgres.
+- Matching is concurrency-safe:
+  - student rows use FOR UPDATE SKIP LOCKED
+  - volunteer row is locked before checking the 10-student cap
+- Supabase Edge Function deployed:
+  https://ccyusgdcruwkpdyteogf.supabase.co/functions/v1/airport-pickup
+- Frontend code now reads REACT_APP_API_URL before falling back to old Apps Script.
+- Local .env.local points frontend builds to Supabase.
+- Google Apps Script is kept only for email.
+- Supabase secret GOOGLE_EMAIL_WEBHOOK_URL points to the Apps Script deployment.
+- Smoke test passed.
+
+Reference smoke-test records left in Supabase
+- Student: reference.student.20260502111828@example.com
+- Volunteer: reference.vol.20260502111828@example.com
+- Match status: Matched
+- Volunteer confirmed: true
+- Volunteer matched_count: 1
+
+Need to do
+- Redeploy the frontend to GitHub Pages.
+- Current blocker: GitHub account/token used here has read access only, not push access.
+- Need a GitHub account/token with push access to RCSSA/Freshmen-Airport-Pickup-Frontend.
+- After access is fixed, run:
+  npm run deploy
+
+Important notes
+- The live GitHub Pages site is not updated yet.
+- A build from this machine will use Supabase because .env.local is set.
+- If deploying from another machine or GitHub Actions, set:
+  REACT_APP_API_URL=https://ccyusgdcruwkpdyteogf.supabase.co/functions/v1/airport-pickup
+- Revoke any Supabase/GitHub tokens pasted during setup.
+- Google Apps Script must include the send_email action for email delivery.

--- a/src/const.js
+++ b/src/const.js
@@ -1,7 +1,8 @@
 // export const serverUrl =
 //   "https://script.google.com/macros/s/AKfycbwSVZc9xwbywtu7FaNXo8kxXUDXfpVsMtSQMgIBd62feVc4n6O7VhP_RKIV1Pc5Rf0n/exec";
-export const serverUrl =
+const googleAppsScriptUrl =
   "https://script.google.com/macros/s/AKfycbwX8ACI5s0lVv3cprhDEWbKF86Nd3WWAncyeQR6JZJZSCMXZTlWNQkI5zmBZAE4lg3f/exec";
+export const serverUrl = process.env.REACT_APP_API_URL || googleAppsScriptUrl;
 export const testUrl =
   "https://script.google.com/macros/s/AKfycbwW_PC-ZKk-4PKK7-uHArZ__2ZZJo5eweyXGqP0iWKmA9MJQIx1_XgQPqA_lyAmIHnM/exec";
 export const siteUrl =

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,2 @@
+[functions.airport-pickup]
+verify_jwt = false

--- a/supabase/functions/airport-pickup/index.ts
+++ b/supabase/functions/airport-pickup/index.ts
@@ -1,0 +1,712 @@
+import { createClient } from "npm:@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error("Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});
+
+type StudentPayload = {
+  firstname: string;
+  lastname: string;
+  phone: string;
+  email: string;
+  wechat?: string;
+  airport: "IAH" | "HOU";
+  arriving_time: string;
+  flight_number?: string;
+};
+
+type VolunteerPayload = {
+  firstname: string;
+  lastname: string;
+  phone: string;
+  email: string;
+  wechat?: string;
+};
+
+type LoginPayload = {
+  firstname: string;
+  lastname: string;
+  email: string;
+};
+
+type MatchPayload = {
+  date: string;
+  hour: string;
+  airport: "IAH" | "HOU";
+  number: number;
+  vol_email: string;
+};
+
+type DeleteStudentPayload = {
+  firstname: string;
+  lastname: string;
+  email: string;
+};
+
+type DeleteMatchPayload = {
+  stud_email: string;
+  vol_email: string;
+};
+
+const hourLabels = Array.from({ length: 12 }, (_, index) => {
+  const start = index * 2;
+  const end = start + 2;
+  return `${String(start).padStart(2, "0")}:00-${String(end).padStart(2, "0")}:00`;
+});
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    const url = new URL(req.url);
+    const action = url.searchParams.get("action");
+
+    switch (action) {
+      case "get_all":
+        return json(await getAll());
+      case "insert_student":
+        return json(await insertStudent(await parseBody<StudentPayload>(req)));
+      case "insert_new_vol":
+        return json(await insertVolunteer(await parseBody<VolunteerPayload>(req)));
+      case "student_login_search":
+        return json(await studentLoginSearch(await parseBody<LoginPayload>(req)));
+      case "volunteer_login_search":
+        return json(await volunteerLoginSearch(await parseBody<LoginPayload>(req)));
+      case "match":
+        return json(await matchStudents(await parseBody<MatchPayload>(req)));
+      case "delete_student":
+        return json(await deleteStudent(await parseBody<DeleteStudentPayload>(req)));
+      case "delete_match_from_volunteer":
+        return json(await deleteMatchFromVolunteer(await parseBody<DeleteMatchPayload>(req)));
+      default:
+        return json({ status: false, message: "Unknown action" }, 400);
+    }
+  } catch (error) {
+    console.error(error);
+    const message = error instanceof Error ? error.message : "Server error";
+    return json({ status: false, message }, 500);
+  }
+});
+
+async function parseBody<T>(req: Request): Promise<T> {
+  const raw = await req.text();
+  if (!raw) return {} as T;
+  return JSON.parse(raw) as T;
+}
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function clean(value: unknown) {
+  return String(value ?? "").trim();
+}
+
+function cleanEmail(value: unknown) {
+  return clean(value).toLowerCase();
+}
+
+function assertRequired(data: Record<string, unknown>, fields: string[]) {
+  for (const field of fields) {
+    if (!clean(data[field])) {
+      throw new Error(`Missing required field: ${field}`);
+    }
+  }
+}
+
+async function insertStudent(data: StudentPayload) {
+  assertRequired(data as unknown as Record<string, unknown>, [
+    "firstname",
+    "lastname",
+    "phone",
+    "email",
+    "airport",
+    "arriving_time",
+  ]);
+
+  const email = cleanEmail(data.email);
+  const { data: existing, error: existingError } = await supabase
+    .from("students")
+    .select("id")
+    .eq("email", email)
+    .maybeSingle();
+
+  if (existingError) throw existingError;
+  if (existing) return { status: false, message: "Student already exists" };
+
+  const { error } = await supabase.from("students").insert({
+    firstname: clean(data.firstname),
+    lastname: clean(data.lastname),
+    phone: clean(data.phone),
+    email,
+    wechat: clean(data.wechat),
+    airport: data.airport,
+    arriving_time: new Date(data.arriving_time).toISOString(),
+    flight_number: clean(data.flight_number),
+  });
+
+  if (error) throw error;
+  await sendEmail(studentSignupEmail(data.firstname, data.lastname, email));
+  return { status: true, message: "done post" };
+}
+
+async function insertVolunteer(data: VolunteerPayload) {
+  assertRequired(data as unknown as Record<string, unknown>, [
+    "firstname",
+    "lastname",
+    "phone",
+    "email",
+  ]);
+
+  const email = cleanEmail(data.email);
+  const { data: existing, error: existingError } = await supabase
+    .from("volunteers")
+    .select("id")
+    .eq("email", email)
+    .maybeSingle();
+
+  if (existingError) throw existingError;
+  if (existing) return { status: false, message: "Volunteer already exists" };
+
+  const { error } = await supabase.from("volunteers").insert({
+    firstname: clean(data.firstname),
+    lastname: clean(data.lastname),
+    phone: clean(data.phone),
+    email,
+    wechat: clean(data.wechat),
+  });
+
+  if (error) throw error;
+  await sendEmail(volunteerSignupEmail(data.firstname, data.lastname, email));
+  return { status: true, message: "done post" };
+}
+
+async function studentLoginSearch(data: LoginPayload) {
+  const email = cleanEmail(data.email);
+  const { data: student, error } = await supabase
+    .from("students")
+    .select("id, firstname, lastname, email, wechat, airport, arriving_time, flight_number")
+    .eq("email", email)
+    .ilike("firstname", clean(data.firstname))
+    .ilike("lastname", clean(data.lastname))
+    .maybeSingle();
+
+  if (error) throw error;
+
+  const returnValue = {
+    found: false,
+    confirmed: true,
+    record: {},
+    wechat: "",
+    airport: "",
+    arriving_time: "",
+    flight_number: "",
+  };
+
+  if (!student) return returnValue;
+
+  returnValue.found = true;
+  returnValue.wechat = student.wechat ?? "";
+  returnValue.airport = student.airport ?? "";
+  returnValue.arriving_time = student.arriving_time ?? "";
+  returnValue.flight_number = student.flight_number ?? "";
+
+  const { data: match, error: matchError } = await supabase
+    .from("matches")
+    .select("volunteer_id")
+    .eq("student_id", student.id)
+    .maybeSingle();
+
+  if (matchError) throw matchError;
+  if (match?.volunteer_id) {
+    const { data: volunteer, error: volunteerError } = await supabase
+      .from("volunteers")
+      .select("firstname, lastname, phone, email, wechat")
+      .eq("id", match.volunteer_id)
+      .maybeSingle();
+
+    if (volunteerError) throw volunteerError;
+    if (!volunteer) return returnValue;
+
+    returnValue.record = {
+      vol_firstname: volunteer.firstname,
+      vol_lastname: volunteer.lastname,
+      vol_phone: volunteer.phone,
+      vol_email: volunteer.email,
+      vol_wechat: volunteer.wechat,
+    };
+  }
+
+  return returnValue;
+}
+
+async function volunteerLoginSearch(data: LoginPayload) {
+  const email = cleanEmail(data.email);
+  const { data: volunteer, error } = await supabase
+    .from("volunteers")
+    .select("id, firstname, lastname, email, confirmed")
+    .eq("email", email)
+    .ilike("firstname", clean(data.firstname))
+    .ilike("lastname", clean(data.lastname))
+    .maybeSingle();
+
+  if (error) throw error;
+
+  const returnValue = {
+    found: false,
+    confirmed: false,
+    record: [] as unknown[],
+  };
+
+  if (!volunteer) return returnValue;
+
+  returnValue.found = true;
+  returnValue.confirmed = Boolean(volunteer.confirmed);
+
+  if (!returnValue.confirmed) return returnValue;
+
+  const { data: matches, error: matchesError } = await supabase
+    .from("matches")
+    .select("student:students(firstname, lastname, phone, email, wechat, airport, arriving_time, flight_number)")
+    .eq("volunteer_id", volunteer.id)
+    .order("matched_at", { ascending: true });
+
+  if (matchesError) throw matchesError;
+
+  returnValue.record = (matches ?? [])
+    .map((match) => Array.isArray(match.student) ? match.student[0] : match.student)
+    .filter(Boolean)
+    .map((student) => ({
+      firstname: student.firstname,
+      lastname: student.lastname,
+      phone: student.phone,
+      email: student.email,
+      wechat: student.wechat,
+      airport: student.airport,
+      arriving_time: student.arriving_time,
+      flight_number: student.flight_number,
+    }));
+
+  return returnValue;
+}
+
+async function getAll() {
+  const { data, error } = await supabase
+    .from("matches")
+    .select("student:students(airport, arriving_time)")
+    .is("volunteer_id", null);
+
+  if (error) throw error;
+
+  const events: Record<string, Record<string, unknown>> = {};
+
+  for (const row of data ?? []) {
+    const student = Array.isArray(row.student) ? row.student[0] : row.student;
+    if (!student?.arriving_time || !student?.airport) continue;
+
+    const { date, hour } = houstonDateHour(student.arriving_time);
+    const hourLabel = hourLabels[Math.floor(hour / 2)];
+    const airport = student.airport as "IAH" | "HOU";
+
+    if (!events[date]) events[date] = createDateStructure(date);
+    const airportBucket = events[date][airport] as Record<string, number>;
+    airportBucket.TotalToBePicked += 1;
+    airportBucket[hourLabel] += 1;
+  }
+
+  for (const date of Object.keys(events)) {
+    for (const airport of ["IAH", "HOU"] as const) {
+      const airportBucket = events[date][airport] as Record<string, number>;
+      for (const key of Object.keys(airportBucket)) {
+        if (key !== "TotalToBePicked" && airportBucket[key] === 0) {
+          delete airportBucket[key];
+        }
+      }
+      if (airportBucket.TotalToBePicked === 0) {
+        delete events[date][airport];
+      }
+    }
+  }
+
+  return { status: true, events };
+}
+
+async function matchStudents(data: MatchPayload) {
+  const [start, end] = parseHourRange(data.hour);
+  const { data: result, error } = await supabase.rpc("allocate_matches", {
+    p_date: data.date,
+    p_start_hour: start,
+    p_end_hour: end,
+    p_airport: data.airport,
+    p_number: Number(data.number),
+    p_vol_email: cleanEmail(data.vol_email),
+  });
+
+  if (error) throw error;
+
+  const row = Array.isArray(result) ? result[0] : result;
+  const numAllocated = row?.num_allocated ?? 0;
+
+  if (numAllocated > 0) {
+    await notifyNewMatches(row?.match_ids ?? []);
+  }
+
+  return {
+    num_allocated: numAllocated,
+    has_reached_limit: Boolean(row?.has_reached_limit),
+  };
+}
+
+async function deleteStudent(data: DeleteStudentPayload) {
+  const email = cleanEmail(data.email);
+  const { data: student, error } = await supabase
+    .from("students")
+    .select("id, firstname, lastname, email")
+    .eq("email", email)
+    .ilike("firstname", clean(data.firstname))
+    .ilike("lastname", clean(data.lastname))
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!student) return { status: false };
+
+  const { data: match, error: matchError } = await supabase
+    .from("matches")
+    .select("volunteer_id")
+    .eq("student_id", student.id)
+    .maybeSingle();
+
+  if (matchError) throw matchError;
+
+  let volunteer = null;
+  if (match?.volunteer_id) {
+    const { data: volunteerData, error: volunteerError } = await supabase
+      .from("volunteers")
+      .select("firstname, lastname, email")
+      .eq("id", match.volunteer_id)
+      .maybeSingle();
+
+    if (volunteerError) throw volunteerError;
+    volunteer = volunteerData;
+  }
+
+  const { error: deleteError } = await supabase
+    .from("students")
+    .delete()
+    .eq("id", student.id);
+
+  if (deleteError) throw deleteError;
+
+  await log("INFO", `STUDENT DELETED : ${student.firstname} ${student.lastname}`, { student_id: student.id });
+  await sendEmail(studentDeleteEmail(student.firstname, student.lastname, student.email));
+
+  if (volunteer?.email) {
+    await sendEmail(studentDeletedVolunteerEmail(
+      student.firstname,
+      student.lastname,
+      volunteer.firstname,
+      volunteer.lastname,
+      volunteer.email,
+    ));
+  }
+
+  return { status: true };
+}
+
+async function deleteMatchFromVolunteer(data: DeleteMatchPayload) {
+  const studentEmail = cleanEmail(data.stud_email);
+  const volunteerEmail = cleanEmail(data.vol_email);
+
+  const { data: student, error: studentError } = await supabase
+    .from("students")
+    .select("id, firstname, lastname, email")
+    .eq("email", studentEmail)
+    .maybeSingle();
+
+  if (studentError) throw studentError;
+  if (!student) return { status: false };
+
+  const { data: volunteer, error: volunteerError } = await supabase
+    .from("volunteers")
+    .select("id, firstname, lastname, email")
+    .eq("email", volunteerEmail)
+    .maybeSingle();
+
+  if (volunteerError) throw volunteerError;
+  if (!volunteer) return { status: false };
+
+  const { data: match, error: matchError } = await supabase
+    .from("matches")
+    .select("id")
+    .eq("student_id", student.id)
+    .eq("volunteer_id", volunteer.id)
+    .maybeSingle();
+
+  if (matchError) throw matchError;
+  if (!match) return { status: false };
+
+  const { error: updateError } = await supabase
+    .from("matches")
+    .update({ volunteer_id: null, matched_at: null })
+    .eq("id", match.id);
+
+  if (updateError) throw updateError;
+
+  await log("INFO", `VOL UNMATCHED : Student: ${student.firstname} ${student.lastname}, Volunteer: ${volunteer.firstname} ${volunteer.lastname}`, {
+    match_id: match.id,
+  });
+
+  await sendEmail(matchDeletedStudentEmail(student.firstname, student.lastname, volunteer.firstname, volunteer.lastname, student.email));
+  await sendEmail(matchDeletedVolunteerEmail(student.firstname, student.lastname, volunteer.firstname, volunteer.lastname, volunteer.email));
+
+  return { status: true };
+}
+
+function createDateStructure(date: string) {
+  const structure: Record<string, unknown> = {
+    date,
+    IAH: { TotalToBePicked: 0 },
+    HOU: { TotalToBePicked: 0 },
+  };
+
+  for (const hourLabel of hourLabels) {
+    (structure.IAH as Record<string, number>)[hourLabel] = 0;
+    (structure.HOU as Record<string, number>)[hourLabel] = 0;
+  }
+
+  return structure;
+}
+
+function houstonDateHour(value: string) {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/Chicago",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(new Date(value));
+
+  const part = (type: string) => parts.find((item) => item.type === type)?.value ?? "";
+  return {
+    date: `${part("year")}-${part("month")}-${part("day")}`,
+    hour: Number(part("hour")),
+  };
+}
+
+function parseHourRange(hour: string) {
+  const match = /^(\d{2}):00-(\d{2}):00$/.exec(hour);
+  if (!match) throw new Error(`Invalid hour range: ${hour}`);
+  return [Number(match[1]), Number(match[2])];
+}
+
+async function notifyNewMatches(matchIds: number[]) {
+  if (matchIds.length === 0) return;
+
+  const { data: matches, error } = await supabase
+    .from("matches")
+    .select("student:students(firstname, lastname, email), volunteer:volunteers(firstname, lastname, email, wechat)")
+    .in("id", matchIds)
+    .order("matched_at", { ascending: false });
+
+  if (error) throw error;
+
+  for (const match of matches ?? []) {
+    const student = Array.isArray(match.student) ? match.student[0] : match.student;
+    const volunteer = Array.isArray(match.volunteer) ? match.volunteer[0] : match.volunteer;
+    if (!student || !volunteer) continue;
+    await sendEmail(newMatchStudentEmail(
+      student.firstname,
+      student.lastname,
+      volunteer.firstname,
+      volunteer.lastname,
+      student.email,
+      volunteer.email,
+      volunteer.wechat,
+    ));
+  }
+}
+
+async function log(level: string, message: string, metadata: Record<string, unknown> = {}) {
+  const { error } = await supabase.from("app_logs").insert({ level, message, metadata });
+  if (error) console.error(error);
+}
+
+type EmailMessage = {
+  to: string;
+  subject: string;
+  body: string;
+};
+
+async function sendEmail(message: EmailMessage) {
+  const webhookUrl = Deno.env.get("GOOGLE_EMAIL_WEBHOOK_URL");
+
+  if (!webhookUrl) {
+    console.log(`Email skipped: ${message.subject} -> ${message.to}`);
+    return;
+  }
+
+  const url = new URL(webhookUrl);
+  url.searchParams.set("action", "send_email");
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      to: message.to,
+      subject: message.subject,
+      body: message.body,
+    }),
+    redirect: "follow",
+  });
+
+  if (!response.ok) {
+    console.error("Google email webhook failed", response.status, await response.text());
+    return;
+  }
+
+  const result = await response.json().catch(() => null);
+  if (result && result.status === false) {
+    console.error("Google email webhook returned failure", result);
+  }
+}
+
+function studentSignupEmail(firstname: string, lastname: string, to: string): EmailMessage {
+  return {
+    to,
+    subject: "[DO NOT REPLY] You Have Signed up as New Student for the RCSSA Airport Pickup Program",
+    body: `Dear ${firstname} ${lastname},
+
+Thank you for registering for the RCSSA Airport Pickup Program. We will notify you when a volunteer has been matched with you.
+
+Sincerely,
+Rice Chinese Students and Scholars Association`,
+  };
+}
+
+function volunteerSignupEmail(firstname: string, lastname: string, to: string): EmailMessage {
+  return {
+    to,
+    subject: "[DO NOT REPLY] You Have Signed up as Volunteer for the RCSSA Airport Pickup Program",
+    body: `Dear ${firstname} ${lastname},
+
+Thank you for signing up to volunteer for the RCSSA Airport Pickup Program. We will notify you after your volunteer status has been approved.
+
+Best regards,
+Rice Chinese Students and Scholars Association`,
+  };
+}
+
+function studentDeleteEmail(firstname: string, lastname: string, to: string): EmailMessage {
+  return {
+    to,
+    subject: "[DO NOT REPLY] You Have Cancelled Your Airport Pickup Request",
+    body: `Dear ${firstname} ${lastname},
+
+Your airport pickup request has been canceled.
+
+Best regards,
+Rice Chinese Students and Scholars Association`,
+  };
+}
+
+function studentDeletedVolunteerEmail(
+  studentFirstname: string,
+  studentLastname: string,
+  volunteerFirstname: string,
+  volunteerLastname: string,
+  to: string,
+): EmailMessage {
+  return {
+    to,
+    subject: "[DO NOT REPLY] You Have Been Unmatched for One Airport Pickup",
+    body: `Dear ${volunteerFirstname} ${volunteerLastname},
+
+The student ${studentFirstname} ${studentLastname}, whom you were assigned to for airport pickup, has canceled their request.
+
+Best regards,
+Rice Chinese Students and Scholars Association`,
+  };
+}
+
+function matchDeletedStudentEmail(
+  studentFirstname: string,
+  studentLastname: string,
+  volunteerFirstname: string,
+  volunteerLastname: string,
+  to: string,
+): EmailMessage {
+  return {
+    to,
+    subject: "[DO NOT REPLY] You Have Been Unmatched for Your Airport Pickup Request",
+    body: `Dear ${studentFirstname} ${studentLastname},
+
+Your assigned volunteer, ${volunteerFirstname} ${volunteerLastname}, has canceled this match. We are working to find a new volunteer for you.
+
+Best regards,
+Rice Chinese Students and Scholars Association`,
+  };
+}
+
+function matchDeletedVolunteerEmail(
+  studentFirstname: string,
+  studentLastname: string,
+  volunteerFirstname: string,
+  volunteerLastname: string,
+  to: string,
+): EmailMessage {
+  return {
+    to,
+    subject: "[DO NOT REPLY] You Have Been Unmatched for One Airport Pickup",
+    body: `Dear ${volunteerFirstname} ${volunteerLastname},
+
+Your airport pickup match with ${studentFirstname} ${studentLastname} has been canceled.
+
+Best regards,
+Rice Chinese Students and Scholars Association`,
+  };
+}
+
+function newMatchStudentEmail(
+  studentFirstname: string,
+  studentLastname: string,
+  volunteerFirstname: string,
+  volunteerLastname: string,
+  to: string,
+  volunteerEmail: string,
+  volunteerWechat: string,
+): EmailMessage {
+  return {
+    to,
+    subject: "[DO NOT REPLY] You Have Been Matched with A Volunteer for Your Airport Pickup Request",
+    body: `Dear ${studentFirstname} ${studentLastname},
+
+You have been matched with ${volunteerFirstname} ${volunteerLastname}. Please contact them by email at ${volunteerEmail} or through WeChat at ${volunteerWechat ?? ""}.
+
+Best regards,
+Rice Chinese Students and Scholars Association`,
+  };
+}

--- a/supabase/migrations/20260502160000_airport_pickup_schema.sql
+++ b/supabase/migrations/20260502160000_airport_pickup_schema.sql
@@ -1,0 +1,214 @@
+create extension if not exists citext;
+
+create table if not exists public.students (
+  id bigint generated always as identity primary key,
+  firstname text not null,
+  lastname text not null,
+  phone text not null,
+  email citext not null unique,
+  wechat text,
+  airport text not null check (airport in ('IAH', 'HOU')),
+  arriving_time timestamptz not null,
+  flight_number text,
+  status text not null default 'Not matched' check (status in ('Not matched', 'Matched')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.volunteers (
+  id bigint generated always as identity primary key,
+  firstname text not null,
+  lastname text not null,
+  phone text not null,
+  email citext not null unique,
+  wechat text,
+  matched_count integer not null default 0 check (matched_count >= 0),
+  confirmed boolean not null default false,
+  notified boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.matches (
+  id bigint generated always as identity primary key,
+  student_id bigint not null unique references public.students(id) on delete cascade,
+  volunteer_id bigint references public.volunteers(id) on delete set null,
+  matched_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.app_logs (
+  id bigint generated always as identity primary key,
+  level text not null default 'INFO',
+  message text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists students_arriving_time_idx on public.students(arriving_time);
+create index if not exists students_airport_idx on public.students(airport);
+create index if not exists volunteers_confirmed_idx on public.volunteers(confirmed);
+create index if not exists matches_volunteer_id_idx on public.matches(volunteer_id);
+create index if not exists matches_student_id_idx on public.matches(student_id);
+
+alter table public.students enable row level security;
+alter table public.volunteers enable row level security;
+alter table public.matches enable row level security;
+alter table public.app_logs enable row level security;
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists students_set_updated_at on public.students;
+create trigger students_set_updated_at
+before update on public.students
+for each row execute function public.set_updated_at();
+
+drop trigger if exists volunteers_set_updated_at on public.volunteers;
+create trigger volunteers_set_updated_at
+before update on public.volunteers
+for each row execute function public.set_updated_at();
+
+drop trigger if exists matches_set_updated_at on public.matches;
+create trigger matches_set_updated_at
+before update on public.matches
+for each row execute function public.set_updated_at();
+
+create or replace function public.create_match_row_for_student()
+returns trigger
+language plpgsql
+as $$
+begin
+  insert into public.matches(student_id)
+  values (new.id)
+  on conflict (student_id) do nothing;
+  return new;
+end;
+$$;
+
+drop trigger if exists students_create_match_row on public.students;
+create trigger students_create_match_row
+after insert on public.students
+for each row execute function public.create_match_row_for_student();
+
+create or replace function public.refresh_match_derived_fields()
+returns trigger
+language plpgsql
+as $$
+begin
+  if tg_op in ('INSERT', 'UPDATE') then
+    update public.students
+    set status = case when new.volunteer_id is null then 'Not matched' else 'Matched' end
+    where id = new.student_id;
+  end if;
+
+  if tg_op in ('UPDATE', 'DELETE') and old.volunteer_id is not null then
+    update public.volunteers
+    set matched_count = (
+      select count(*)::integer
+      from public.matches
+      where volunteer_id = old.volunteer_id
+    )
+    where id = old.volunteer_id;
+  end if;
+
+  if tg_op in ('INSERT', 'UPDATE') and new.volunteer_id is not null then
+    update public.volunteers
+    set matched_count = (
+      select count(*)::integer
+      from public.matches
+      where volunteer_id = new.volunteer_id
+    )
+    where id = new.volunteer_id;
+  end if;
+
+  return coalesce(new, old);
+end;
+$$;
+
+drop trigger if exists matches_refresh_derived_fields on public.matches;
+create trigger matches_refresh_derived_fields
+after insert or update or delete on public.matches
+for each row execute function public.refresh_match_derived_fields();
+
+create or replace function public.allocate_matches(
+  p_date date,
+  p_start_hour integer,
+  p_end_hour integer,
+  p_airport text,
+  p_number integer,
+  p_vol_email citext
+)
+returns table(num_allocated integer, has_reached_limit boolean, match_ids bigint[])
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_volunteer_id bigint;
+  v_current_count integer;
+  v_remaining integer;
+begin
+  if p_number is null or p_number <= 0 then
+    return query select 0, false, array[]::bigint[];
+    return;
+  end if;
+
+  select id
+  into v_volunteer_id
+  from public.volunteers
+  where email = p_vol_email
+    and confirmed is true
+  for update;
+
+  if v_volunteer_id is null then
+    return query select 0, false, array[]::bigint[];
+    return;
+  end if;
+
+  select count(*)::integer
+  into v_current_count
+  from public.matches
+  where volunteer_id = v_volunteer_id;
+
+  if v_current_count >= 10 then
+    return query select 0, true, array[]::bigint[];
+    return;
+  end if;
+
+  v_remaining := least(p_number, 10 - v_current_count);
+
+  return query
+  with candidates as (
+    select m.id
+    from public.matches m
+    join public.students s on s.id = m.student_id
+    where m.volunteer_id is null
+      and s.airport = p_airport
+      and (s.arriving_time at time zone 'America/Chicago')::date = p_date
+      and extract(hour from s.arriving_time at time zone 'America/Chicago') >= p_start_hour
+      and extract(hour from s.arriving_time at time zone 'America/Chicago') < p_end_hour
+    order by s.arriving_time, s.id
+    limit v_remaining
+    for update of m skip locked
+  ),
+  updated as (
+    update public.matches m
+    set volunteer_id = v_volunteer_id,
+        matched_at = now()
+    from candidates c
+    where m.id = c.id
+    returning m.id
+  )
+  select count(*)::integer, false, coalesce(array_agg(id), array[]::bigint[])
+  from updated;
+end;
+$$;


### PR DESCRIPTION
Supabase migration progress

Done
- Supabase project connected: ccyusgdcruwkpdyteogf
- Database migration applied.
- Tables created: students, volunteers, matches, app_logs.
- Matching logic moved to Supabase/Postgres.
- Matching is concurrency-safe:
  - student rows use FOR UPDATE SKIP LOCKED
  - volunteer row is locked before checking the 10-student cap
- Supabase Edge Function deployed:
  https://ccyusgdcruwkpdyteogf.supabase.co/functions/v1/airport-pickup
- Frontend code now reads REACT_APP_API_URL before falling back to old Apps Script.
- Local .env.local points frontend builds to Supabase.
- Google Apps Script is kept only for email.
- Supabase secret GOOGLE_EMAIL_WEBHOOK_URL points to the Apps Script deployment.
- Smoke test passed.

Reference smoke-test records left in Supabase
- Student: reference.student.20260502111828@example.com
- Volunteer: reference.vol.20260502111828@example.com
- Match status: Matched
- Volunteer confirmed: true
- Volunteer matched_count: 1

Need to do
- Redeploy the frontend to GitHub Pages.
- Current blocker: GitHub account/token used here has read access only, not push access.
- Need a GitHub account/token with push access to RCSSA/Freshmen-Airport-Pickup-Frontend.
- After access is fixed, run:
  npm run deploy

Important notes
- The live GitHub Pages site is not updated yet.
- A build from this machine will use Supabase because .env.local is set.
- If deploying from another machine or GitHub Actions, set:
  REACT_APP_API_URL=https://ccyusgdcruwkpdyteogf.supabase.co/functions/v1/airport-pickup
- Revoke any Supabase/GitHub tokens pasted during setup.
- Google Apps Script must include the send_email action for email delivery.
